### PR TITLE
feat: Upgrade WebIDE to Monaco VS Code Engine

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,8 @@ from fastapi import (
     BackgroundTasks,
     HTTPException,
 )
+from pydantic import BaseModel
+from github import Github
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -83,6 +85,11 @@ class StartRequest(BaseModel):
     repo_name: str
     target_issue: Optional[int] = None
 
+class FileUpdateRequest(BaseModel):
+    file_path: str
+    content: str
+    commit_message: Optional[str] = None
+
 
 active_task: Optional[asyncio.Task] = None
 
@@ -96,6 +103,27 @@ async def start_agents(req: StartRequest):
         run_agent_loop(req.repo_name, manager, req.target_issue)
     )
     return {"status": "started"}
+
+@app.post("/repo/{repo_name:path}/file")
+async def update_repo_file(repo_name: str, payload: FileUpdateRequest):
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise HTTPException(status_code=401, detail="GitHub token not configured")
+    gh = Github(token)
+    try:
+        repo = gh.get_repo(repo_name)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Repository not found: {e}")
+    try:
+        file = repo.get_contents(payload.file_path)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"File not found in repo: {e}")
+    message = payload.commit_message or f"Update {payload.file_path} via AutoMaintainer IDE"
+    try:
+        repo.update_file(file.path, message, payload.content, file.sha)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to update file: {e}")
+    return {"status": "updated", "message": message}
 
 
 @app.post("/stop")

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "framer-motion": "^12.40.0",
         "lucide-react": "^1.17.0",
         "next": "16.2.6",
@@ -1048,6 +1049,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1632,6 +1656,14 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2965,6 +2997,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5175,6 +5217,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5230,6 +5285,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/motion-dom": {
@@ -6279,6 +6345,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "framer-motion": "^12.40.0",
     "lucide-react": "^1.17.0",
     "next": "16.2.6",

--- a/dashboard/src/components/WebIDE.tsx
+++ b/dashboard/src/components/WebIDE.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { ChevronRight, ChevronDown, File as FileIcon, FolderOpen, Folder } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { ChevronRight, ChevronDown, File as FileIcon, FolderOpen, Folder, Save } from "lucide-react";
+import Editor from "@monaco-editor/react";
 
 interface TreeNode {
   name: string;
@@ -104,6 +103,9 @@ export default function WebIDE({ repoUrl }: WebIDEProps) {
   const [loadingTree, setLoadingTree] = useState(true);
   const [loadingFile, setLoadingFile] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [editedContent, setEditedContent] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const hasUnsavedChanges = editedContent !== null && editedContent !== fileContent;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -148,6 +150,7 @@ export default function WebIDE({ repoUrl }: WebIDEProps) {
         }
         const data = await res.json();
         setFileContent(data.content);
+        setEditedContent(data.content);
       } catch (err: unknown) {
         if (err instanceof Error && err.name === "AbortError") return;
         setFileContent(`// Error loading file: ${err instanceof Error ? err.message : String(err)}`);
@@ -158,6 +161,39 @@ export default function WebIDE({ repoUrl }: WebIDEProps) {
     fetchFile();
     return () => controller.abort();
   }, [activeFile, repoUrl]);
+
+  const handleSave = async () => {
+    if (!activeFile || !editedContent) return;
+    setIsSaving(true);
+    try {
+      const backendUrl = getBackendUrl();
+      const res = await fetch(`${backendUrl}/repo/${encodeURIComponent(repoUrl)}/file`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          file_path: activeFile,
+          content: editedContent
+        })
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      setFileContent(editedContent);
+    } catch (err) {
+      alert("Failed to save file: " + (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [activeFile, editedContent, repoUrl]);
 
   const getLanguage = (filename: string) => {
     const ext = filename.split(".").pop()?.toLowerCase();
@@ -208,11 +244,20 @@ export default function WebIDE({ repoUrl }: WebIDEProps) {
         {activeFile ? (
           <>
             {/* Editor Tab Bar */}
-            <div className="flex bg-[#252526] h-9 items-end shrink-0 overflow-x-auto custom-scrollbar">
+            <div className="flex bg-[#252526] h-9 items-end shrink-0 overflow-x-auto custom-scrollbar justify-between pr-2">
               <div className="bg-[#1e1e1e] text-[#cccccc] px-3 py-2 flex items-center gap-2 text-sm border-t border-[#007acc] min-w-fit">
                 <FileIcon className="w-3.5 h-3.5 text-[#519aba]" />
                 {activeFile.split("/").pop()}
+                {hasUnsavedChanges && <span className="w-2 h-2 bg-white rounded-full ml-1"></span>}
               </div>
+              <button 
+                onClick={handleSave}
+                disabled={!hasUnsavedChanges || isSaving}
+                className={`flex items-center gap-1 px-3 py-1 text-xs rounded transition-colors mb-1 ${hasUnsavedChanges ? 'bg-[#0e639c] text-white hover:bg-[#1177bb]' : 'text-zinc-500 cursor-not-allowed'}`}
+              >
+                <Save className="w-3 h-3" />
+                {isSaving ? "Saving..." : "Save"}
+              </button>
             </div>
             
             {/* Editor Breadcrumbs */}
@@ -223,25 +268,23 @@ export default function WebIDE({ repoUrl }: WebIDEProps) {
             </div>
 
             {/* Code Content */}
-            <div className="flex-1 overflow-auto bg-[#1e1e1e] relative">
+            <div className="flex-1 overflow-hidden bg-[#1e1e1e] relative">
               {loadingFile ? (
                 <div className="p-8 text-[#cccccc] text-sm animate-pulse">Loading file content...</div>
               ) : fileContent !== null ? (
-                <SyntaxHighlighter
+                <Editor
+                  height="100%"
+                  theme="vs-dark"
                   language={getLanguage(activeFile)}
-                  style={vscDarkPlus}
-                  customStyle={{
-                    margin: 0,
-                    padding: "16px",
-                    background: "transparent",
-                    fontSize: "14px",
-                    lineHeight: "1.5",
+                  value={editedContent ?? fileContent}
+                  onChange={(value) => setEditedContent(value ?? "")}
+                  options={{
+                    minimap: { enabled: true },
+                    fontSize: 14,
+                    wordWrap: "on",
+                    padding: { top: 16 }
                   }}
-                  showLineNumbers={true}
-                  wrapLines={true}
-                >
-                  {fileContent}
-                </SyntaxHighlighter>
+                />
               ) : null}
             </div>
           </>


### PR DESCRIPTION
## Description
Replaced the static \eact-syntax-highlighter\ with the full \@monaco-editor/react\ engine to provide a native VS Code experience in the browser. 

Added full file read/write capabilities:
- **Backend**: New \POST /repo/{repo_name}/file\ endpoint to push commits to the repository using the PyGithub API.
- **Frontend**: A dedicated \Save\ button in the tab bar and \Ctrl+S\ shortcut listener to intercept keyboard saves and trigger the backend push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added web-based code editor with syntax highlighting for editing repository files.
  * Repository files can now be edited directly and saved back to GitHub.
  * Added keyboard shortcut (Ctrl/⌘+S) to save file changes.
  * Unsaved changes indicator and save button in the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->