### PR TITLE
fix: Resolve hardcoded websocket url in terminal

### DIFF
--- a/dashboard/src/components/InteractiveTerminal.tsx
+++ b/dashboard/src/components/InteractiveTerminal.tsx
@@ -42,10 +42,21 @@ export default function InteractiveTerminal({ repoUrl }: InteractiveTerminalProp
     fitAddon.current = fit;
 
     // Build the WebSocket URL
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const host = process.env.NEXT_PUBLIC_BACKEND_URL
-      ? process.env.NEXT_PUBLIC_BACKEND_URL.replace("http://", "").replace("https://", "")
-      : "localhost:8000";
+    let backendUrl = "http://localhost:8000";
+    if (process.env.NEXT_PUBLIC_BACKEND_URL) {
+      backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL.replace(/\/$/, "");
+    } else if (typeof window !== "undefined") {
+      const port = window.location.port;
+      const hostname = window.location.hostname;
+      if (port === "3000") {
+        backendUrl = `${window.location.protocol}//${hostname}:8000`;
+      } else {
+        backendUrl = `${window.location.protocol}//${window.location.host}`;
+      }
+    }
+    
+    const protocol = backendUrl.startsWith("https") ? "wss:" : "ws:";
+    const host = backendUrl.replace(/^https?:\/\//, "");
     
     let wsUrl = `${protocol}//${host}/api/terminal/ws`;
     if (repoUrl) {


### PR DESCRIPTION
This fixes the InteractiveTerminal falling back to localhost:8000 when deployed to Hugging Face or other production environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend URL configuration handling for the interactive terminal, enabling better support for environment-based server settings and various deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->