### PR TITLE
fix(security): Resolve CodeQL path traversal vulnerabilities

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -345,24 +345,26 @@ def get_repo_tree(repo_name: str):
 
 @app.get("/repo/{repo_name:path}/file")
 def get_repo_file(repo_name: str, file_path: str):
-    base_tmp = os.path.abspath("/tmp")
-    clean_name = repo_name.replace("/", "_").replace("\\", "_")
-    repo_dir = os.path.abspath(os.path.join(base_tmp, clean_name))
+    from pathlib import Path
 
-    if not repo_dir.startswith(base_tmp + os.sep):
+    base_tmp = Path("/tmp").resolve()
+    clean_name = repo_name.replace("/", "_").replace("\\", "_")
+    repo_dir = (base_tmp / clean_name).resolve()
+
+    if not repo_dir.is_relative_to(base_tmp):
         raise HTTPException(status_code=400, detail="Invalid repository name")
 
-    target_path = os.path.abspath(os.path.join(repo_dir, file_path))
+    target_path = (repo_dir / file_path).resolve()
 
     # Strict path traversal security check for CodeQL
-    if not target_path.startswith(repo_dir + os.sep) and target_path != repo_dir:
+    if not target_path.is_relative_to(repo_dir):
         raise HTTPException(status_code=403, detail="Invalid file path")
 
-    if not os.path.exists(target_path) or not os.path.isfile(target_path):
+    if not target_path.exists() or not target_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")
 
     try:
-        with open(target_path, "r", encoding="utf-8") as f:
+        with target_path.open("r", encoding="utf-8") as f:
             content = f.read()
         return {"content": content}
     except UnicodeDecodeError:

--- a/backend/main.py
+++ b/backend/main.py
@@ -354,26 +354,44 @@ def get_repo_file(repo_name: str, file_path: str):
     if not repo_dir.is_relative_to(base_tmp):
         raise HTTPException(status_code=400, detail="Invalid repository name")
 
-    target_path = (repo_dir / file_path).resolve()
+    try:
+        target_path = (repo_dir / file_path).resolve()
+    except (OSError, RuntimeError) as e:
+        logger.warning(f"Error resolving path {file_path}: {e}")
+        raise HTTPException(status_code=400, detail="Invalid or looping file path")
 
     # Strict path traversal security check for CodeQL
     if not target_path.is_relative_to(repo_dir):
         raise HTTPException(status_code=403, detail="Invalid file path")
 
-    if not target_path.exists() or not target_path.is_file():
+    import os, stat
+    try:
+        fd = os.open(target_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError:
         raise HTTPException(status_code=404, detail="File not found")
 
     try:
-        with target_path.open("r", encoding="utf-8") as f:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        with os.fdopen(fd, "r", encoding="utf-8") as f:
             content = f.read()
         return {"content": content}
     except UnicodeDecodeError:
         raise HTTPException(status_code=415, detail="Cannot read binary file")
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"Failed to read file {target_path}: {e}")
         raise HTTPException(
             status_code=500, detail="An internal error occurred while reading the file"
         )
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 # Serve the static Next.js frontend if the out directory exists


### PR DESCRIPTION
This PR refactors the \get_repo_file\ path construction to use Python's \pathlib.Path.resolve()\ and \.is_relative_to()\. This securely sanitizes the untrusted \ile_path\ input and natively resolves CodeQL alerts #9, #10, and #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path validation to prevent path traversal and unauthorized file access; invalid repository names and file paths are now rejected.
  * More precise error responses for different failure scenarios (client errors, not found, unsupported content, server errors) to aid troubleshooting.
  * Improved reliability of file reads and cleanup to reduce intermittent read failures and resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->