### PR TITLE
fix(ci): fix auto-changelog workflow to preserve existing content

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -121,13 +121,6 @@ jobs:
           # Create temporary file with new entry
           TEMP_FILE=$(mktemp)
           
-          # Read existing content up to Unreleased section
-          awk '/^## \[Unreleased\]/{print; found=1; next} found{exit} !found{print}' "$CHANGELOG_FILE" > "$TEMP_FILE"
-          
-          # Add Unreleased header
-          echo "## [Unreleased]" >> "$TEMP_FILE"
-          echo "" >> "$TEMP_FILE"
-          
           # Add new entry under appropriate category
           PR_TYPE="${{ steps.pr-info.outputs.pr_type }}"
           PR_TITLE="${{ steps.pr-info.outputs.pr_title }}"
@@ -135,68 +128,115 @@ jobs:
           PR_URL="${{ steps.pr-info.outputs.pr_url }}"
           PR_AUTHOR="${{ steps.pr-info.outputs.pr_author }}"
           
-          # Check if category exists, if not create it
+          # Find the line number of "## [Unreleased]" and the next version header
+          UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" "$CHANGELOG_FILE" | head -1 | cut -d: -f1)
+          
+          if [ -z "$UNRELEASED_LINE" ]; then
+            echo "Error: Could not find Unreleased section"
+            exit 1
+          fi
+          
+          # Find the next version header after Unreleased
+          NEXT_VERSION_LINE=$(tail -n +"$((UNRELEASED_LINE + 1))" "$CHANGELOG_FILE" | grep -n "^## \[" | head -1 | cut -d: -f1)
+          
+          if [ -n "$NEXT_VERSION_LINE" ]; then
+            NEXT_VERSION_LINE=$((UNRELEASED_LINE + NEXT_VERSION_LINE))
+          else
+            NEXT_VERSION_LINE=$(wc -l < "$CHANGELOG_FILE")
+          fi
+          
+          # Extract the Unreleased section content (excluding the header)
+          UNRELEASED_CONTENT=$(sed -n "$((UNRELEASED_LINE + 1)),$((NEXT_VERSION_LINE - 1))p" "$CHANGELOG_FILE")
+          
+          # Check if the category already exists in the Unreleased section
           CATEGORY_FOUND=false
           case $PR_TYPE in
             "added")
-              if grep -q "### Added" "$TEMP_FILE"; then
+              if echo "$UNRELEASED_CONTENT" | grep -q "### Added"; then
                 CATEGORY_FOUND=true
               fi
               ;;
             "changed")
-              if grep -q "### Changed" "$TEMP_FILE"; then
+              if echo "$UNRELEASED_CONTENT" | grep -q "### Changed"; then
                 CATEGORY_FOUND=true
               fi
               ;;
             "fixed")
-              if grep -q "### Fixed" "$TEMP_FILE"; then
+              if echo "$UNRELEASED_CONTENT" | grep -q "### Fixed"; then
                 CATEGORY_FOUND=true
               fi
               ;;
             "documentation")
-              if grep -q "### Documentation" "$TEMP_FILE"; then
+              if echo "$UNRELEASED_CONTENT" | grep -q "### Documentation"; then
                 CATEGORY_FOUND=true
               fi
               ;;
             "maintenance")
-              if grep -q "### Maintenance" "$TEMP_FILE"; then
+              if echo "$UNRELEASED_CONTENT" | grep -q "### Maintenance"; then
                 CATEGORY_FOUND=true
               fi
               ;;
           esac
           
-          # Add category if not found
-          if [ "$CATEGORY_FOUND" = false ]; then
+          # Build the new Unreleased section
+          NEW_UNRELEASED="## [Unreleased]"
+          NEW_UNRELEASED="$NEW_UNRELEASED"$'\n'
+          
+          if [ "$CATEGORY_FOUND" = true ]; then
+            # Category exists, add entry under it
             case $PR_TYPE in
               "added")
-                echo "### Added" >> "$TEMP_FILE"
-                echo "" >> "$TEMP_FILE"
+                NEW_UNRELEASED="$NEW_UNRELEASED$(echo "$UNRELEASED_CONTENT" | sed '/^### Added$/a\- '"$PR_TITLE"' ([#'"$PR_NUMBER"']('"$PR_URL"')) - @'"$PR_AUTHOR")"
                 ;;
               "changed")
-                echo "### Changed" >> "$TEMP_FILE"
-                echo "" >> "$TEMP_FILE"
+                NEW_UNRELEASED="$NEW_UNRELEASED$(echo "$UNRELEASED_CONTENT" | sed '/^### Changed$/a\- '"$PR_TITLE"' ([#'"$PR_NUMBER"']('"$PR_URL"')) - @'"$PR_AUTHOR")"
                 ;;
               "fixed")
-                echo "### Fixed" >> "$TEMP_FILE"
-                echo "" >> "$TEMP_FILE"
+                NEW_UNRELEASED="$NEW_UNRELEASED$(echo "$UNRELEASED_CONTENT" | sed '/^### Fixed$/a\- '"$PR_TITLE"' ([#'"$PR_NUMBER"']('"$PR_URL"')) - @'"$PR_AUTHOR")"
                 ;;
               "documentation")
-                echo "### Documentation" >> "$TEMP_FILE"
-                echo "" >> "$TEMP_FILE"
+                NEW_UNRELEASED="$NEW_UNRELEASED$(echo "$UNRELEASED_CONTENT" | sed '/^### Documentation$/a\- '"$PR_TITLE"' ([#'"$PR_NUMBER"']('"$PR_URL"')) - @'"$PR_AUTHOR")"
                 ;;
               "maintenance")
-                echo "### Maintenance" >> "$TEMP_FILE"
-                echo "" >> "$TEMP_FILE"
+                NEW_UNRELEASED="$NEW_UNRELEASED$(echo "$UNRELEASED_CONTENT" | sed '/^### Maintenance$/a\- '"$PR_TITLE"' ([#'"$PR_NUMBER"']('"$PR_URL"')) - @'"$PR_AUTHOR")"
                 ;;
             esac
+          else
+            # Category doesn't exist, add it with the entry
+            NEW_UNRELEASED="$NEW_UNRELEASED"$'\n'
+            case $PR_TYPE in
+              "added")
+                NEW_UNRELEASED="$NEW_UNRELEASED### Added"$'\n'
+                ;;
+              "changed")
+                NEW_UNRELEASED="$NEW_UNRELEASED### Changed"$'\n'
+                ;;
+              "fixed")
+                NEW_UNRELEASED="$NEW_UNRELEASED### Fixed"$'\n'
+                ;;
+              "documentation")
+                NEW_UNRELEASED="$NEW_UNRELEASED### Documentation"$'\n'
+                ;;
+              "maintenance")
+                NEW_UNRELEASED="$NEW_UNRELEASED### Maintenance"$'\n'
+                ;;
+            esac
+            NEW_UNRELEASED="$NEW_UNRELEASED"$'\n'
+            NEW_UNRELEASED="$NEW_UNRELEASED- $PR_TITLE ([#$PR_NUMBER]($PR_URL)) - @$PR_AUTHOR"$'\n'
+            NEW_UNRELEASED="$NEW_UNRELEASED"$'\n'
+            NEW_UNRELEASED="$NEW_UNRELEASED$UNRELEASED_CONTENT"
           fi
           
-          # Add the entry
-          echo "- ${PR_TITLE} ([#${PR_NUMBER}](${PR_URL})) - @${PR_AUTHOR}" >> "$TEMP_FILE"
+          # Build the final file
+          # 1. Content before Unreleased section
+          head -n "$((UNRELEASED_LINE - 1))" "$CHANGELOG_FILE" > "$TEMP_FILE"
+          
+          # 2. New Unreleased section
+          echo "$NEW_UNRELEASED" >> "$TEMP_FILE"
           echo "" >> "$TEMP_FILE"
           
-          # Add remaining content (skip old Unreleased section and any existing entries)
-          awk '/^## \[.*\]/{if(/## \[Unreleased\]/){skip=1; next} else{skip=0}} !skip{print}' "$CHANGELOG_FILE" >> "$TEMP_FILE"
+          # 3. Content after Unreleased section (remaining versions)
+          tail -n +"$NEXT_VERSION_LINE" "$CHANGELOG_FILE" >> "$TEMP_FILE"
           
           # Replace original file
           mv "$TEMP_FILE" "$CHANGELOG_FILE"


### PR DESCRIPTION
### Description

This PR fixes the auto-changelog workflow that was removing existing content from the Unreleased section.

### Problem

The previous workflow used an awk command that was not properly preserving existing entries in the Unreleased section. When a new PR was merged, it would overwrite the entire Unreleased section with only the new entry.

### Solution

1. Fixed the awk command: Changed the logic to properly extract and preserve existing Unreleased content
2. Improved category handling: Better logic for adding entries under existing categories
3. Restored CHANGELOG.md: Restored all the content that was removed by the previous workflow run

### Changes

- Fixed the workflow to preserve existing Unreleased entries
- Restored CHANGELOG.md with all previous content
- Improved the logic for handling existing categories
- Added better error handling

### Testing

The workflow will be tested when this PR is merged. It should:
1. Preserve all existing Unreleased entries
2. Add the new entry under the appropriate category
3. Not remove any existing content

### Related Issues

- Fixes issue introduced in PR #68