### PR TITLE
fix: remove duplicate BaseModel import in main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from github import Github
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+
 from typing import Optional
 from agents import run_agent_loop
 import asyncio


### PR DESCRIPTION
## Description
Removes the duplicate `from pydantic import BaseModel` import in `main.py`. The import was present on both line 8 and line 12, causing `flake8` to report `F811` (redefinition of unused name from import) and reducing code readability.

## Changes
- Removed duplicate `from pydantic import BaseModel` on line 12

## Verification
Verified with `flake8 --select=F811 main.py` — the reported F811 for `BaseModel` is resolved.

> Note: an unrelated F811 for `platform` (line 61) still exists in the file but is outside the scope of this issue.

## Related Issue
Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a duplicate internal import.
  * No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->