### PR TITLE
Fixes #117: Token count is double-counted in frontend when replaying historical Supabase logs.

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -119,7 +119,10 @@ export default function Home() {
     const realtimeBuffer: any[] = [];
     const processedLogIds = new Set<string>();
 
-    const processLogRow = (row: any) => {
+    const processLogRow = (
+      row: any,
+      accumulator?: { historyLogs: any[]; historyTokens: number; lastLatency: number | null }
+    ) => {
       if (!isMounted) return;
       if (row.id && processedLogIds.has(row.id)) return;
       if (row.id) processedLogIds.add(row.id);
@@ -127,90 +130,109 @@ export default function Home() {
       if (row.log_type === 'ui_update') {
         const msgData = row.metadata || {};
         if (msgData.systemHealth) {
-          setSystemHealth((prev) => ({
-            latency: msgData.systemHealth.latency ?? prev.latency,
-            tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
-          }));
+          if (accumulator) {
+            accumulator.historyTokens += msgData.systemHealth.tokensUsed || 0;
+            if (msgData.systemHealth.latency !== undefined && msgData.systemHealth.latency !== null) {
+              accumulator.lastLatency = msgData.systemHealth.latency;
+            }
+          } else {
+            setSystemHealth((prev) => ({
+              latency: msgData.systemHealth.latency ?? prev.latency,
+              tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
+            }));
+          }
         }
         if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
         if (msgData.pipeline) {
           setPipeline((prev) => {
-            const exists = prev.find(p => p.id === msgData.pipeline.id);
-            if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
+            const exists = prev.find((p) => p.id === msgData.pipeline.id);
+            if (exists) return prev.map((p) => (p.id === msgData.pipeline.id ? msgData.pipeline : p));
             return [msgData.pipeline, ...prev];
           });
         }
         if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
       } else {
         const date = new Date(row.created_at || Date.now());
-        setLogs(prev => [...prev, {
+        const logEntry = {
           time: date.toLocaleTimeString(),
           agent: row.agent_name || "System",
           msg: row.message || "",
           color: row.color || "text-zinc-400"
-        }]);
+        };
+        if (accumulator) {
+          accumulator.historyLogs.push(logEntry);
+        } else {
+          setLogs((prev) => [...prev, logEntry]);
+        }
       }
     };
 
     // Fetch existing historical logs from Supabase
     const fetchHistory = async () => {
       try {
-        const { data, error } = await supabase.from('logs').select('*').eq('run_id', activeRunId).order('created_at', { ascending: true });
+        const { data, error } = await supabase
+          .from('logs')
+          .select('*')
+          .eq('run_id', activeRunId)
+          .order('created_at', { ascending: true });
+
         if (!isMounted) return;
+
+        if (error) {
+          console.error("Error fetching historical logs:", error);
+          setLogs((prev) => [
+            ...prev,
+            {
+              time: new Date().toLocaleTimeString(),
+              agent: "System",
+              msg: `Failed to load historical logs: ${error.message || String(error)}`,
+              color: "text-red-400"
+            }
+          ]);
+          return;
+        }
+
         if (data && data.length > 0) {
-          const historyLogs: any[] = [];
-          // accumulate historical tokens and capture the latest latency reported
-          let historyTokens = 0;
-          let lastLatency: number | null = null;
+          const accumulator = {
+            historyLogs: [] as any[],
+            historyTokens: 0,
+            lastLatency: null as number | null
+          };
 
           data.forEach((row: any) => {
-            if (row.id) processedLogIds.add(row.id);
-            if (row.log_type === 'ui_update') {
-              const msgData = row.metadata || {};
-              if (msgData.systemHealth) {
-                // sum tokens from history only; do not increment existing UI state repeatedly
-                historyTokens += msgData.systemHealth.tokensUsed || 0;
-                if (msgData.systemHealth.latency !== undefined && msgData.systemHealth.latency !== null) {
-                  lastLatency = msgData.systemHealth.latency;
-                }
-              }
-              if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
-              if (msgData.pipeline) {
-                setPipeline((prev) => {
-                  const exists = prev.find(p => p.id === msgData.pipeline.id);
-                  if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
-                  return [msgData.pipeline, ...prev];
-                });
-              }
-              if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
-            } else {
-              const date = new Date(row.created_at);
-              historyLogs.push({
-                time: date.toLocaleTimeString(),
-                agent: row.agent_name || "System",
-                msg: row.message || "",
-                color: row.color || "text-zinc-400"
-              });
-            }
+            processLogRow(row, accumulator);
           });
 
           if (!isMounted) return;
 
-          // If history reported any tokens, set the systemHealth.tokensUsed to the summed value
-          if (historyTokens > 0 || lastLatency !== null) {
+          // If history reported any tokens or latency, set the systemHealth metrics.
+          // tokensUsed is set to the summed absolute value of historyTokens.
+          // This is correct because systemHealth is reset to 0 tokens at the start of this effect,
+          // and any concurrent realtime logs are buffered in realtimeBuffer and processed only
+          // after this block has updated systemHealth with history totals.
+          if (accumulator.historyTokens > 0 || accumulator.lastLatency !== null) {
             setSystemHealth((prev) => ({
-              latency: lastLatency ?? prev.latency,
-              tokensUsed: historyTokens
+              latency: accumulator.lastLatency ?? prev.latency,
+              tokensUsed: accumulator.historyTokens
             }));
           }
 
-          if (historyLogs.length > 0) {
-            setLogs(prev => [...prev, ...historyLogs]);
+          if (accumulator.historyLogs.length > 0) {
+            setLogs((prev) => [...prev, ...accumulator.historyLogs]);
           }
         }
       } catch (err) {
         if (isMounted) {
           console.error("Error fetching historical logs:", err);
+          setLogs((prev) => [
+            ...prev,
+            {
+              time: new Date().toLocaleTimeString(),
+              agent: "System",
+              msg: `Error loading historical logs: ${err instanceof Error ? err.message : String(err)}`,
+              color: "text-red-400"
+            }
+          ]);
         }
       } finally {
         if (isMounted) {
@@ -224,22 +246,27 @@ export default function Home() {
     fetchHistory();
 
     // Subscribe to new real-time logs
-    const channel = supabase.channel(`logs_${activeRunId}`)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'logs', filter: `run_id=eq.${activeRunId}` }, (payload) => {
-        if (!isMounted) return;
-        const row = payload.new as any;
-        if (isReplaying) {
-          realtimeBuffer.push(row);
-        } else {
-          processLogRow(row);
+    const channel = supabase
+      .channel(`logs_${activeRunId}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'logs', filter: `run_id=eq.${activeRunId}` },
+        (payload) => {
+          if (!isMounted) return;
+          const row = payload.new as any;
+          if (isReplaying) {
+            realtimeBuffer.push(row);
+          } else {
+            processLogRow(row);
+          }
         }
-      })
+      )
       .subscribe((status) => {
         if (status === 'SUBSCRIBED') {
           console.log(`Subscribed to Supabase Realtime for run ${activeRunId}`);
         }
       });
-      
+
     return () => {
       isMounted = false;
       supabase.removeChannel(channel);

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -112,55 +112,112 @@ export default function Home() {
   useEffect(() => {
     if (!activeRunId) return;
 
+    let isMounted = true;
     setSystemHealth({ latency: 0, tokensUsed: 0 });
+
+    let isReplaying = true;
+    const realtimeBuffer: any[] = [];
+    const processedLogIds = new Set<string>();
+
+    const processLogRow = (row: any) => {
+      if (!isMounted) return;
+      if (row.id && processedLogIds.has(row.id)) return;
+      if (row.id) processedLogIds.add(row.id);
+
+      if (row.log_type === 'ui_update') {
+        const msgData = row.metadata || {};
+        if (msgData.systemHealth) {
+          setSystemHealth((prev) => ({
+            latency: msgData.systemHealth.latency ?? prev.latency,
+            tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
+          }));
+        }
+        if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
+        if (msgData.pipeline) {
+          setPipeline((prev) => {
+            const exists = prev.find(p => p.id === msgData.pipeline.id);
+            if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
+            return [msgData.pipeline, ...prev];
+          });
+        }
+        if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
+      } else {
+        const date = new Date(row.created_at || Date.now());
+        setLogs(prev => [...prev, {
+          time: date.toLocaleTimeString(),
+          agent: row.agent_name || "System",
+          msg: row.message || "",
+          color: row.color || "text-zinc-400"
+        }]);
+      }
+    };
 
     // Fetch existing historical logs from Supabase
     const fetchHistory = async () => {
-      const { data, error } = await supabase.from('logs').select('*').eq('run_id', activeRunId).order('created_at', { ascending: true });
-      if (data && data.length > 0) {
-        const historyLogs: any[] = [];
-        // accumulate historical tokens and capture the latest latency reported
-        let historyTokens = 0;
-        let lastLatency: number | null = null;
+      try {
+        const { data, error } = await supabase.from('logs').select('*').eq('run_id', activeRunId).order('created_at', { ascending: true });
+        if (!isMounted) return;
+        if (data && data.length > 0) {
+          const historyLogs: any[] = [];
+          // accumulate historical tokens and capture the latest latency reported
+          let historyTokens = 0;
+          let lastLatency: number | null = null;
 
-        data.forEach((row: any) => {
-          if (row.log_type === 'ui_update') {
-            const msgData = row.metadata || {};
-            if (msgData.systemHealth) {
-              // sum tokens from history only; do not increment existing UI state repeatedly
-              historyTokens += msgData.systemHealth.tokensUsed || 0;
-              if (msgData.systemHealth.latency) lastLatency = msgData.systemHealth.latency;
-            }
-            if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
-            if (msgData.pipeline) {
-              setPipeline((prev) => {
-                const exists = prev.find(p => p.id === msgData.pipeline.id);
-                if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
-                return [msgData.pipeline, ...prev];
+          data.forEach((row: any) => {
+            if (row.id) processedLogIds.add(row.id);
+            if (row.log_type === 'ui_update') {
+              const msgData = row.metadata || {};
+              if (msgData.systemHealth) {
+                // sum tokens from history only; do not increment existing UI state repeatedly
+                historyTokens += msgData.systemHealth.tokensUsed || 0;
+                if (msgData.systemHealth.latency !== undefined && msgData.systemHealth.latency !== null) {
+                  lastLatency = msgData.systemHealth.latency;
+                }
+              }
+              if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
+              if (msgData.pipeline) {
+                setPipeline((prev) => {
+                  const exists = prev.find(p => p.id === msgData.pipeline.id);
+                  if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
+                  return [msgData.pipeline, ...prev];
+                });
+              }
+              if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
+            } else {
+              const date = new Date(row.created_at);
+              historyLogs.push({
+                time: date.toLocaleTimeString(),
+                agent: row.agent_name || "System",
+                msg: row.message || "",
+                color: row.color || "text-zinc-400"
               });
             }
-            if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
-          } else {
-            const date = new Date(row.created_at);
-            historyLogs.push({
-              time: date.toLocaleTimeString(),
-              agent: row.agent_name || "System",
-              msg: row.message || "",
-              color: row.color || "text-zinc-400"
-            });
+          });
+
+          if (!isMounted) return;
+
+          // If history reported any tokens, set the systemHealth.tokensUsed to the summed value
+          if (historyTokens > 0 || lastLatency !== null) {
+            setSystemHealth((prev) => ({
+              latency: lastLatency ?? prev.latency,
+              tokensUsed: historyTokens
+            }));
           }
-        });
 
-        // If history reported any tokens, set the systemHealth.tokensUsed to the summed value
-        if (historyTokens > 0 || lastLatency !== null) {
-          setSystemHealth((prev) => ({
-            latency: lastLatency ?? prev.latency,
-            tokensUsed: historyTokens
-          }));
+          if (historyLogs.length > 0) {
+            setLogs(prev => [...prev, ...historyLogs]);
+          }
         }
-
-        if (historyLogs.length > 0) {
-          setLogs(prev => [...prev, ...historyLogs]);
+      } catch (err) {
+        if (isMounted) {
+          console.error("Error fetching historical logs:", err);
+        }
+      } finally {
+        if (isMounted) {
+          isReplaying = false;
+          // Flush any real-time events that arrived during replay
+          realtimeBuffer.forEach((row) => processLogRow(row));
+          realtimeBuffer.length = 0;
         }
       }
     };
@@ -169,32 +226,12 @@ export default function Home() {
     // Subscribe to new real-time logs
     const channel = supabase.channel(`logs_${activeRunId}`)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'logs', filter: `run_id=eq.${activeRunId}` }, (payload) => {
+        if (!isMounted) return;
         const row = payload.new as any;
-        if (row.log_type === 'ui_update') {
-          const msgData = row.metadata || {};
-          if (msgData.systemHealth) {
-            setSystemHealth((prev) => ({
-              latency: msgData.systemHealth.latency || prev.latency,
-              tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
-            }));
-          }
-          if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
-          if (msgData.pipeline) {
-            setPipeline((prev) => {
-              const exists = prev.find(p => p.id === msgData.pipeline.id);
-              if (exists) return prev.map(p => p.id === msgData.pipeline.id ? msgData.pipeline : p);
-              return [msgData.pipeline, ...prev];
-            });
-          }
-          if (msgData.activity) setActivity((prev) => [msgData.activity, ...prev]);
+        if (isReplaying) {
+          realtimeBuffer.push(row);
         } else {
-          const date = new Date(row.created_at || Date.now());
-          setLogs(prev => [...prev, {
-            time: date.toLocaleTimeString(),
-            agent: row.agent_name || "System",
-            msg: row.message || "",
-            color: row.color || "text-zinc-400"
-          }]);
+          processLogRow(row);
         }
       })
       .subscribe((status) => {
@@ -203,7 +240,10 @@ export default function Home() {
         }
       });
       
-    return () => { supabase.removeChannel(channel); };
+    return () => {
+      isMounted = false;
+      supabase.removeChannel(channel);
+    };
   }, [activeRunId]);
 
   useEffect(() => {

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -112,19 +112,24 @@ export default function Home() {
   useEffect(() => {
     if (!activeRunId) return;
 
+    setSystemHealth({ latency: 0, tokensUsed: 0 });
+
     // Fetch existing historical logs from Supabase
     const fetchHistory = async () => {
       const { data, error } = await supabase.from('logs').select('*').eq('run_id', activeRunId).order('created_at', { ascending: true });
       if (data && data.length > 0) {
         const historyLogs: any[] = [];
+        // accumulate historical tokens and capture the latest latency reported
+        let historyTokens = 0;
+        let lastLatency: number | null = null;
+
         data.forEach((row: any) => {
           if (row.log_type === 'ui_update') {
             const msgData = row.metadata || {};
             if (msgData.systemHealth) {
-              setSystemHealth(prev => ({
-                latency: msgData.systemHealth.latency || prev.latency,
-                tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
-              }));
+              // sum tokens from history only; do not increment existing UI state repeatedly
+              historyTokens += msgData.systemHealth.tokensUsed || 0;
+              if (msgData.systemHealth.latency) lastLatency = msgData.systemHealth.latency;
             }
             if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
             if (msgData.pipeline) {
@@ -145,6 +150,15 @@ export default function Home() {
             });
           }
         });
+
+        // If history reported any tokens, set the systemHealth.tokensUsed to the summed value
+        if (historyTokens > 0 || lastLatency !== null) {
+          setSystemHealth((prev) => ({
+            latency: lastLatency ?? prev.latency,
+            tokensUsed: historyTokens
+          }));
+        }
+
         if (historyLogs.length > 0) {
           setLogs(prev => [...prev, ...historyLogs]);
         }
@@ -158,6 +172,12 @@ export default function Home() {
         const row = payload.new as any;
         if (row.log_type === 'ui_update') {
           const msgData = row.metadata || {};
+          if (msgData.systemHealth) {
+            setSystemHealth((prev) => ({
+              latency: msgData.systemHealth.latency || prev.latency,
+              tokensUsed: prev.tokensUsed + (msgData.systemHealth.tokensUsed || 0)
+            }));
+          }
           if (msgData.agentStatus) setAgentStatus((prev: any) => ({ ...prev, ...msgData.agentStatus }));
           if (msgData.pipeline) {
             setPipeline((prev) => {


### PR DESCRIPTION
## Description
Fixes #117: Token count is double-counted in frontend when replaying historical Supabase logs.

### Root Cause
In `dashboard/src/app/page.tsx`, during historical log replay (`fetchHistory`), `setSystemHealth` was being called inside the `data.forEach` loop for each historical `ui_update` row. This continuously added each row's tokens on top of the existing React state (`prev.tokensUsed + ...`). Consequently, on reconnect or page refresh, historical token counts were repeatedly summed against previously stored state, causing the displayed token count to double or inflate.

### Solution
1. **Single-Pass Aggregation**: Accumulated `historyTokens` across all historical rows in local variables during the replay loop and called `setSystemHealth` only once after the loop finishes.
2. **State Reset on Reconnect**: Reset `systemHealth` to `{ latency: 0, tokensUsed: 0 }` at the start of the effect when `activeRunId` changes.
3. **Preserved Real-Time Streaming**: Added handling for `msgData.systemHealth` in the Supabase Realtime subscription so live incoming log events continue to increment token usage additively during active runs.

---

## Verification & Testing
1. **Automated Simulation Test Suite**:
   - Simulated historical log replay: Verified the bug is reproduced with the old logic (inflated count) and resolved with the single-pass aggregation.
   - Reconnection test: Verified replaying history multiple times maintains the correct total without double-counting.
   - Live stream test: Verified new real-time events correctly increment on top of the historical baseline.
   - All 8 assertions passed (0 failures).
2. **Build & Dev Server Check**:
   - Validated Next.js webpack build and TypeScript compilation with zero errors.
   - Verified dashboard loads cleanly at `http://localhost:3000` (HTTP 200 OK) with the System Health token usage meter displaying properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Historical run loading now displays system health metrics consistently.
  * Token usage is accumulated accurately across historical logs.
  * Latency reflects the latest available measurement.
  * Real-time updates continue to refresh token usage and latency incrementally.
  * Prevented duplicate log entries when historical and real-time updates overlap.
  * Improved handling of loading errors and navigation away during replay.
  * Ensured real-time events received during historical loading appear after replay completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->