### PR TITLE
fix(docs): update OpenSSF Scorecard badge and viewer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pinned: false
 **An Always-On Autonomous AI Software Engineering Team**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/PxA-Labs/AutoMaintainer/badge)](https://scorecard.dev/viewer/?site=github.com/PxA-Labs/AutoMaintainer)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/PxA-Labs/AutoMaintainer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/PxA-Labs/AutoMaintainer)
 [![CI Backend](https://github.com/PxA-Labs/AutoMaintainer/actions/workflows/ci-backend.yml/badge.svg)](https://github.com/PxA-Labs/AutoMaintainer/actions/workflows/ci-backend.yml)
 [![CodeQL](https://github.com/PxA-Labs/AutoMaintainer/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/PxA-Labs/AutoMaintainer/actions/workflows/codeql-analysis.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/)


### PR DESCRIPTION
Updates the OpenSSF Scorecard badge and viewer URL in \README.md\ to the official \https://securityscorecards.dev/viewer/?uri=github.com/PxA-Labs/AutoMaintainer\ endpoint.