### PR TITLE
Fix #143: Randomize sandbox repo name in test_fs_api.py to prevent workspace collision

### DIFF
--- a/backend/test_fs_api.py
+++ b/backend/test_fs_api.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import uuid
 import pytest
 from fastapi.testclient import TestClient
 from main import app, get_safe_repo_dir
@@ -9,7 +10,7 @@ client = TestClient(app)
 
 @pytest.fixture(autouse=True)
 def setup_dummy_repo():
-    repo_name = "PxA-Labs/AutoMaintainer"
+    repo_name = f"PxA-Labs/AutoMaintainerTestSandbox-{uuid.uuid4().hex[:8]}"
     repo_dir = get_safe_repo_dir(repo_name)
 
     if repo_dir.exists():


### PR DESCRIPTION
## Bug

The `setup_dummy_repo` fixture in `backend/test_fs_api.py` hardcoded `repo_name = "PxA-Labs/AutoMaintainer"`. This gets sanitized by `get_safe_repo_dir()` into a folder like `<workspace_dir>/PxA-Labs_AutoMaintainer`.

If a developer has the real `PxA-Labs/AutoMaintainer` repo checked out in that same workspace directory (as the actual agent does during normal operation), running `pytest` would call `shutil.rmtree()` on that folder **before and after each test** — silently deleting real, uncommitted work.

## Fix

1. Added `import uuid` at the top of `backend/test_fs_api.py`.
2. Changed the hardcoded `repo_name` to a randomized, collision-proof sandbox name:

```python
repo_name = f"PxA-Labs/AutoMaintainerTestSandbox-{uuid.uuid4().hex[:8]}"
```

The new name uses only letters, numbers, hyphens — fully matching `get_safe_repo_dir()`'s validation regex `^[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)?$` in `backend/workspace.py`.

No other fixture logic (directory creation, file writes, teardown) was changed.

## Test Run

All 3 tests pass with the fix applied:

```
platform win32 -- Python 3.12.10, pytest-9.1.1
collected 3 items

backend/test_fs_api.py::test_tree_endpoint PASSED
backend/test_fs_api.py::test_file_endpoint_valid PASSED
backend/test_fs_api.py::test_file_endpoint_path_traversal PASSED

3 passed
```

Fixes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by assigning each test run a unique repository name.
  * Reduced the risk of conflicts between repeated or parallel test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->