### PR TITLE
Fix #141: Reset all dashboard states (logs, pipeline, activity, agentStatus) on new agent run

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -114,6 +114,16 @@ export default function Home() {
 
     let isMounted = true;
     setSystemHealth({ latency: 0, tokensUsed: 0 });
+    setLogs([{ time: new Date().toLocaleTimeString(), agent: "System", msg: "Connecting...", color: "text-zinc-500" }]);
+    setPipeline([]);
+    setActivity([]);
+    setAgentStatus({
+      Architect: 'idle',
+      Visionary: 'idle',
+      Reviewer: 'idle',
+      Implementer: 'idle',
+      Maintainer: 'idle',
+    });
 
     let isReplaying = true;
     const realtimeBuffer: any[] = [];


### PR DESCRIPTION
## Bug Description

When a new agent run starts and `activeRunId` changes, the `useEffect` hook in `dashboard/src/app/page.tsx` only reset `systemHealth` to `{ latency: 0, tokensUsed: 0 }`.

The `logs`, `pipeline`, `activity`, and `agentStatus` React states retained their values from the previous agent run. This caused:
- Stale log entries from the previous run to remain in the console UI mixed with new logs.
- Stale pipeline entries and activity feed items to persist.
- `agentStatus` indicators (Architect, Visionary, Reviewer, Implementer, Maintainer) to retain leftover 'active'/other statuses from the previous run instead of resetting to 'idle'.

## Fix

Added explicit state reset calls inside the `activeRunId` `useEffect` in `dashboard/src/app/page.tsx`, immediately following `setSystemHealth`:

```tsx
setLogs([{ time: new Date().toLocaleTimeString(), agent: "System", msg: "Connecting...", color: "text-zinc-500" }]);
setPipeline([]);
setActivity([]);
setAgentStatus({
  Architect: 'idle',
  Visionary: 'idle',
  Reviewer: 'idle',
  Implementer: 'idle',
  Maintainer: 'idle',
});
```

## Validation & Test Output

`npm run lint` and `npm run build` executed cleanly in `dashboard/`:

```text
> dashboard@0.1.0 lint
> eslint

C:\Users\rahul\Downloads\AutoMaintainer\dashboard\src\app\page.tsx
  1:1  warning  Unused eslint-disable directive
  3:1  warning  Unused eslint-disable directive
  4:1  warning  Unused eslint-disable directive

✖ 3 problems (0 errors, 3 warnings)

> dashboard@0.1.0 build
> next build

▲ Next.js 16.3.0 (Turbopack)
✓ Running next.config.ts took 109ms
  Creating an optimized production build ...
✓ Compiled successfully in 15.9s
  Running TypeScript ...
  Finished TypeScript in 4.5s ...
  Collecting page data using 5 workers ...
✓ Generating static pages using 5 workers (4/4) in 1752ms
```

Fixes #141
