### PR TITLE
feat(deploy): add Vercel and Render deployment configs

### DIFF
--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "cleanUrls": true,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+services:
+  - type: web
+    name: automaintainer-backend
+    env: python
+    region: oregon
+    plan: starter
+    rootDir: backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
+    autoDeploy: true
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.0"
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_KEY
+        sync: false
+      - key: GROQ_API_KEY
+        sync: false
+      - key: GITHUB_TOKEN
+        sync: false
+      - key: ALLOWED_ORIGINS
+        sync: false


### PR DESCRIPTION
Adds \ender.yaml\ for 1-click FastAPI backend deployment on Render and \dashboard/vercel.json\ with strict security headers for Next.js on Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment configuration for the dashboard with clean URLs and enhanced security headers.
  * Added automated backend deployment configuration, including health checks and automatic deploys.
  * Added support for configuring runtime environment values securely through the hosting platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->