### PR TITLE
fix(vercel): standardize next.config.ts and vercel.json for Vercel deployment

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'export',
-  distDir: 'out',
+  /* Next.js standard config for Vercel */
 };
 
 export default nextConfig;

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "cleanUrls": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Removes \distDir: 'out'\ and \output: 'export'\ from \dashboard/next.config.ts\ to enable native Next.js build output (\.next\) on Vercel and cleans \dashboard/vercel.json\ to prevent 404 NOT_FOUND errors.