### PR TITLE
fix(vercel): add root package.json and vercel.json for monorepo auto-detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "automaintainer",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": [
+    "dashboard"
+  ],
+  "scripts": {
+    "dev": "npm --prefix dashboard run dev",
+    "build": "npm --prefix dashboard run build",
+    "start": "npm --prefix dashboard run start",
+    "lint": "npm --prefix dashboard run lint"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm --prefix dashboard run build",
+  "outputDirectory": "dashboard/.next"
+}


### PR DESCRIPTION
Adds root \package.json\ with npm workspaces delegation to \dashboard/\ and root \ercel.json\ to guarantee automatic Next.js build detection on Vercel regardless of root directory settings.