### PR TITLE
fix(deploy): configure static export out directory for Docker and Vercel

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* Next.js standard config for Vercel */
+  output: 'export',
 };
 
 export default nextConfig;

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "outputDirectory": "out",
   "headers": [
     {
       "source": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
+  "cleanUrls": true,
   "buildCommand": "npm --prefix dashboard run build",
-  "outputDirectory": "dashboard/.next"
+  "outputDirectory": "dashboard/out"
 }


### PR DESCRIPTION
Restores \output: 'export'\ in Next.js config to produce \dashboard/out\ for both Docker image build and Vercel static deployment.