### PR TITLE
fix(agents): handle empty MCP agent streams explicitly

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -140,6 +140,26 @@ class AgentState(TypedDict):
     log_messages: Annotated[list, operator.add]
 
 
+class EmptyAgentStreamError(RuntimeError):
+    """Raised when an MCP agent stream contains no usable final response."""
+
+
+def extract_final_agent_content(final_res) -> str:
+    """Return the final streamed message or raise a descriptive protocol error."""
+    if not isinstance(final_res, dict):
+        raise EmptyAgentStreamError("MCP agent stream returned no agent result.")
+
+    messages = final_res.get("messages")
+    if not messages:
+        raise EmptyAgentStreamError("MCP agent stream returned no messages.")
+
+    content = getattr(messages[-1], "content", None)
+    if not isinstance(content, str) or not content.strip():
+        raise EmptyAgentStreamError("MCP agent stream returned an empty final message.")
+
+    return content
+
+
 async def run_llm(
     system_prompt: str, user_prompt: str, estimated_tokens: int = 2000
 ) -> str:
@@ -288,7 +308,7 @@ async def run_llm_with_tools(
                                             }
                                         )
 
-                    return final_res["messages"][-1].content
+                    return extract_final_agent_content(final_res)
 
                 return await manager.execute_with_retry(
                     _call_with_tools, estimated_tokens=estimated_tokens

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -122,6 +122,7 @@ def get_all_groq_keys():
 
 
 import operator
+from collections.abc import Sequence
 
 
 class AgentState(TypedDict):
@@ -152,6 +153,10 @@ def extract_final_agent_content(final_res) -> str:
     messages = final_res.get("messages")
     if not messages:
         raise EmptyAgentStreamError("MCP agent stream returned no messages.")
+    if isinstance(messages, (str, bytes, bytearray)) or not isinstance(
+        messages, Sequence
+    ):
+        raise EmptyAgentStreamError("MCP agent stream returned malformed messages.")
 
     content = getattr(messages[-1], "content", None)
     if not isinstance(content, str) or not content.strip():
@@ -286,11 +291,13 @@ async def run_llm_with_tools(
                                 )
                         if "agent" in chunk:
                             final_res = chunk["agent"]
+                            messages = chunk["agent"].get("messages")
                             if (
-                                "messages" in chunk["agent"]
-                                and len(chunk["agent"]["messages"]) > 0
+                                isinstance(messages, Sequence)
+                                and not isinstance(messages, (str, bytes, bytearray))
+                                and messages
                             ):
-                                msg = chunk["agent"]["messages"][-1]
+                                msg = messages[-1]
                                 if (
                                     hasattr(msg, "usage_metadata")
                                     and msg.usage_metadata

--- a/backend/test_agents_unit.py
+++ b/backend/test_agents_unit.py
@@ -155,6 +155,12 @@ def test_extract_final_agent_content_returns_content():
     )
 
 
+def test_extract_final_agent_content_rejects_malformed_truthy_messages():
+    for malformed in ({"unexpected": "shape"}, 1, "not-a-message-list"):
+        with pytest.raises(EmptyAgentStreamError, match="malformed messages"):
+            extract_final_agent_content({"messages": malformed})
+
+
 def test_should_implement():
     # PM Decision APPROVED -> implementer
     state_approved = {"pm_decision": "  APPROVED with fixes "}

--- a/backend/test_agents_unit.py
+++ b/backend/test_agents_unit.py
@@ -3,7 +3,9 @@ import asyncio
 import httpx
 from unittest.mock import MagicMock
 from agents import (
+    EmptyAgentStreamError,
     broadcast_log,
+    extract_final_agent_content,
     extract_target_file,
     get_all_groq_keys,
     normalize_generated_code,
@@ -128,6 +130,29 @@ def test_get_all_groq_keys(monkeypatch):
     assert "key-1" in keys
     assert "key-2" in keys
     assert len(keys) >= 3
+
+
+def test_extract_final_agent_content_rejects_missing_result():
+    with pytest.raises(EmptyAgentStreamError, match="no agent result"):
+        extract_final_agent_content(None)
+
+
+def test_extract_final_agent_content_rejects_missing_messages():
+    with pytest.raises(EmptyAgentStreamError, match="no messages"):
+        extract_final_agent_content({})
+
+
+def test_extract_final_agent_content_rejects_empty_message():
+    message = MagicMock(content="   ")
+    with pytest.raises(EmptyAgentStreamError, match="empty final message"):
+        extract_final_agent_content({"messages": [message]})
+
+
+def test_extract_final_agent_content_returns_content():
+    message = MagicMock(content="architectural response")
+    assert (
+        extract_final_agent_content({"messages": [message]}) == "architectural response"
+    )
 
 
 def test_should_implement():

--- a/backend/test_runners.py
+++ b/backend/test_runners.py
@@ -1,4 +1,6 @@
+import re
 import subprocess
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -133,8 +135,9 @@ async def test_local_runner_git_diff(temp_workspace):
     await runner.write_file("README.md", "# Modified Title\n")
 
     diff = await runner.get_git_diff()
-    assert "-# Test Repo" in diff
-    assert "+# Modified Title" in diff
+    plain_diff = re.sub(r"\x1b\[[0-9;]*m", "", diff)
+    assert "-# Test Repo" in plain_diff
+    assert "+# Modified Title" in plain_diff
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related Issues
Closes #110

## Type of Change
- [x] Bug fix (non-breaking change fixing an existing issue)

## Technical Summary & Architectural Impact
`run_llm_with_tools` now validates the streamed MCP agent result before accessing its messages. It raises a descriptive `EmptyAgentStreamError` for missing agent results, missing messages, or empty final content instead of silently treating a protocol failure as a normal fallback. The fallback behavior for other failures, including rate limits, remains unchanged.

## Quality & Security Verification
- [x] Code follows the project style guidelines.
- [x] Python code was formatted with Black.
- [x] `pytest backend/` passes: 21 tests passed.
- [x] Added regression tests for missing results, missing messages, empty content, and valid content.
- [x] No unvalidated path or security-sensitive behavior was introduced.

## AI-Assisted Contribution Policy & Integrity
- [x] Every line was manually inspected and verified against local execution.
- [x] This pull request contains no unverified AI-hallucinated code or mock assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty, incomplete, or malformed AI agent responses.
  - Clear errors are now reported when results, messages, or final content are missing.
  - Prevented invalid agent responses from being incorrectly processed through the generic fallback.

- **Tests**
  - Added coverage for missing results, missing messages, empty messages, malformed responses, and valid agent content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->