### PR TITLE
fix(api): configure CORS origins for deployed frontends

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ import logging
 from pathlib import Path
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from urllib.parse import urlsplit
 
 # Celery integration
 from celery_app import celery_app
@@ -258,10 +259,48 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="AutoMaintainer Backend", lifespan=lifespan)
 
-# Allow the Next.js frontend to connect to this API
+
+DEFAULT_ALLOWED_ORIGINS = (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+)
+
+
+def parse_allowed_origins(configured_origins: str | None) -> list[str]:
+    """Return safe, normalized CORS origins from a comma-separated setting."""
+    candidates = list(DEFAULT_ALLOWED_ORIGINS)
+    if configured_origins:
+        candidates.extend(origin.strip() for origin in configured_origins.split(","))
+
+    origins = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        parsed = urlsplit(candidate)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "ALLOWED_ORIGINS must contain comma-separated http(s) origins "
+                f"without paths or wildcards: {candidate!r}"
+            )
+        normalized = f"{parsed.scheme}://{parsed.netloc}"
+        if normalized not in origins:
+            origins.append(normalized)
+    return origins
+
+
+ALLOWED_ORIGINS = parse_allowed_origins(os.getenv("ALLOWED_ORIGINS"))
+
+# Allow the Next.js frontend to connect to this API. Origins are exact matches;
+# wildcard origins are intentionally rejected because credentials are enabled.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/test_agents_unit.py
+++ b/backend/test_agents_unit.py
@@ -10,6 +10,7 @@ from agents import (
     should_implement,
     should_iterate,
 )
+from main import parse_allowed_origins
 from workspace import get_base_workspace_dir, get_safe_repo_dir, get_safe_target_path
 from fastapi import HTTPException
 
@@ -114,6 +115,47 @@ async def test_implementer_creates_explicit_missing_target_file(monkeypatch):
     repo.create_file.assert_called_once()
     assert repo.create_file.call_args.kwargs["path"] == "backend/new_feature.py"
     assert result["target_file_path"] == "backend/new_feature.py"
+
+
+def test_parse_allowed_origins_includes_defaults_and_configured_values():
+    origins = parse_allowed_origins(
+        "https://dashboard.example.com, https://dashboard.example.com/"
+    )
+
+    assert origins == [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://dashboard.example.com",
+    ]
+
+
+def test_parse_allowed_origins_rejects_wildcards_and_paths():
+    with pytest.raises(ValueError, match="without paths or wildcards"):
+        parse_allowed_origins("*")
+
+    with pytest.raises(ValueError, match="without paths or wildcards"):
+        parse_allowed_origins("https://dashboard.example.com/app")
+
+
+def test_cors_preflight_uses_exact_configured_origins():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    client = TestClient(app)
+    request_headers = {
+        "Origin": "http://localhost:3000",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type",
+    }
+    response = client.options("/start", headers=request_headers)
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+    request_headers["Origin"] = "http://localhost.evil.test"
+    rejected = client.options("/start", headers=request_headers)
+    assert rejected.status_code == 400
+    assert "access-control-allow-origin" not in rejected.headers
 
 
 def test_get_all_groq_keys(monkeypatch):

--- a/backend/test_runners.py
+++ b/backend/test_runners.py
@@ -1,4 +1,6 @@
+import re
 import subprocess
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -133,8 +135,9 @@ async def test_local_runner_git_diff(temp_workspace):
     await runner.write_file("README.md", "# Modified Title\n")
 
     diff = await runner.get_git_diff()
-    assert "-# Test Repo" in diff
-    assert "+# Modified Title" in diff
+    plain_diff = re.sub(r"\x1b\[[0-9;]*m", "", diff)
+    assert "-# Test Repo" in plain_diff
+    assert "+# Modified Title" in plain_diff
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related Issues
Closes #51

## Type of Change
- [x] Bug fix (non-breaking change fixing an existing issue)

## Technical Summary & Architectural Impact
The backend now reads `ALLOWED_ORIGINS` as a comma-separated environment setting and validates each origin as an exact HTTP(S) origin without paths, query strings, fragments, or wildcards. Localhost defaults remain available for development, while deployed Next.js frontends can use an explicit production origin. Wildcards are rejected because credentialed CORS is enabled.

## Quality & Security Verification
- [x] Code follows the project style guidelines.
- [x] Python code was formatted with Black.
- [x] `pytest backend/` passes: 20 tests passed.
- [x] Added regression tests for normalization, wildcard/path rejection, allowed preflight, and rejected origins.
- [x] No unvalidated path traversal or permissive wildcard CORS behavior was introduced.

## AI-Assisted Contribution Policy & Integrity
- [x] Every line was manually inspected and verified against local execution.
- [x] This pull request contains no unverified AI-hallucinated code or mock assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved cross-origin request handling with validated, explicitly configured origins.
  * Added support for safely normalizing configured origins and rejecting invalid, wildcard, or path-based values.

* **Bug Fixes**
  * Prevented unauthorized origins from receiving cross-origin access.
  * Improved handling of preflight requests for approved origins.

* **Tests**
  * Added coverage for origin normalization, invalid configuration rejection, and exact preflight behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->