### PR TITLE
fix: run scheduled GitHub App repository sync

### DIFF
--- a/backend/github_app.py
+++ b/backend/github_app.py
@@ -6,6 +6,8 @@ Replaces PAT-based authentication with GitHub App installation tokens.
 import os
 import time
 import json
+import asyncio
+from datetime import datetime, timezone
 import jwt
 import httpx
 from typing import Optional, Dict, Any
@@ -144,29 +146,31 @@ async def sync_installation_repositories(
             continue
 
         try:
-            await supabase_client.table("repositories").upsert(
-                {
-                    "id": repo_data["id"],
-                    "org_id": org_id,
-                    "github_installation_id": installation_id,
-                    "full_name": repo_data["full_name"],
-                    "name": repo_data["name"],
-                    "owner_login": repo_data["owner_login"],
-                    "owner_type": repo_data["owner_type"],
-                    "private": repo_data["private"],
-                    "default_branch": repo_data["default_branch"],
-                    "description": repo_data["description"],
-                    "language": repo_data["language"],
-                    "topics": repo_data["topics"],
-                    "avatar_url": repo_data["avatar_url"],
-                    "html_url": repo_data["html_url"],
-                    "archived": repo_data["archived"],
-                    "disabled": repo_data["disabled"],
-                    "pushed_at": repo_data["pushed_at"],
-                    "synced_at": time.time(),
-                },
-                on_conflict="id",
-            ).execute()
+            repository_record = {
+                "id": repo_data["id"],
+                "org_id": org_id,
+                "github_installation_id": installation_id,
+                "full_name": repo_data["full_name"],
+                "name": repo_data["name"],
+                "owner_login": repo_data["owner_login"],
+                "owner_type": repo_data["owner_type"],
+                "private": repo_data["private"],
+                "default_branch": repo_data["default_branch"],
+                "description": repo_data["description"],
+                "language": repo_data["language"],
+                "topics": repo_data["topics"],
+                "avatar_url": repo_data["avatar_url"],
+                "html_url": repo_data["html_url"],
+                "archived": repo_data["archived"],
+                "disabled": repo_data["disabled"],
+                "pushed_at": repo_data["pushed_at"],
+                "synced_at": datetime.now(timezone.utc).isoformat(),
+            }
+            await asyncio.to_thread(
+                lambda: supabase_client.table("repositories")
+                .upsert(repository_record, on_conflict="id")
+                .execute()
+            )
             synced += 1
         except Exception as e:
             logger.error(f"Failed to sync repo {repo_data['full_name']}: {e}")

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -44,6 +44,7 @@ except ImportError:
 from supabase import create_client, Client
 
 from agents import run_agent_loop, broadcast_log
+from github_app import sync_installation_repositories
 
 logger = logging.getLogger(__name__)
 
@@ -428,24 +429,51 @@ def sync_repositories(self):
         result = loop.run_until_complete(
             asyncio.to_thread(
                 lambda: sb.table("github_installations")
-                .select("id, org_id, account_login, access_token")
+                .select("id, org_id, account_login")
                 .is_("suspended_at", "null")
                 .execute()
             )
         )
 
         installations = result.data or []
-        synced_count = 0
+        repositories_synced = 0
+        errors = []
 
         for install in installations:
-            # This would use GitHub App token to fetch repos
-            # Implementation depends on GitHub App integration (next task)
-            logger.info(
-                f"Would sync repos for installation {install['id']} ({install['account_login']})"
-            )
-            synced_count += 1
+            installation_id = install["id"]
+            account_login = install["account_login"]
+            try:
+                synced = loop.run_until_complete(
+                    sync_installation_repositories(
+                        sb, installation_id, install["org_id"]
+                    )
+                )
+                repositories_synced += synced
+                logger.info(
+                    "Synced %s repositories for installation %s (%s)",
+                    synced,
+                    installation_id,
+                    account_login,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Failed to sync installation %s (%s)",
+                    installation_id,
+                    account_login,
+                )
+                errors.append(
+                    {
+                        "installation_id": installation_id,
+                        "account_login": account_login,
+                        "error": str(exc),
+                    }
+                )
 
-        return {"installations_processed": synced_count}
+        return {
+            "installations_processed": len(installations),
+            "repositories_synced": repositories_synced,
+            "errors": errors,
+        }
 
     except Exception as e:
         logger.exception(f"Sync repositories failed: {e}")

--- a/backend/test_github_sync.py
+++ b/backend/test_github_sync.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import github_app
+import tasks
+
+
+@pytest.mark.asyncio
+async def test_sync_installation_repositories_upserts_active_repositories():
+    supabase = MagicMock()
+    upsert_method = MagicMock()
+    upsert_result = MagicMock()
+    upsert_method.return_value = upsert_result
+    upsert_result.execute.return_value = SimpleNamespace(data=[])
+    supabase.table.return_value.upsert = upsert_method
+
+    repos = [
+        {
+            "id": 42,
+            "full_name": "acme/app",
+            "name": "app",
+            "owner_login": "acme",
+            "owner_type": "Organization",
+            "private": True,
+            "default_branch": "main",
+            "description": "App",
+            "language": "Python",
+            "topics": [],
+            "avatar_url": "https://example.test/avatar.png",
+            "html_url": "https://github.com/acme/app",
+            "archived": False,
+            "disabled": False,
+            "pushed_at": None,
+        },
+        {
+            "id": 43,
+            "full_name": "acme/archived",
+            "name": "archived",
+            "owner_login": "acme",
+            "owner_type": "Organization",
+            "private": False,
+            "default_branch": "main",
+            "description": None,
+            "language": None,
+            "topics": [],
+            "avatar_url": "",
+            "html_url": "",
+            "archived": True,
+            "disabled": False,
+            "pushed_at": None,
+        },
+    ]
+
+    with patch.object(
+        github_app, "get_installation_repositories", new=AsyncMock(return_value=repos)
+    ):
+        synced = await github_app.sync_installation_repositories(supabase, 7, "org-1")
+
+    assert synced == 1
+    record = upsert_method.call_args.args[0]
+    assert record["id"] == 42
+    assert record["org_id"] == "org-1"
+    assert record["github_installation_id"] == 7
+    assert isinstance(record["synced_at"], str)
+    upsert_method.assert_called_once_with(record, on_conflict="id")
+    upsert_result.execute.assert_called_once_with()
+
+
+def test_sync_repositories_calls_installation_sync():
+    supabase = MagicMock()
+    query = supabase.table.return_value.select.return_value.is_.return_value
+    query.execute.return_value = SimpleNamespace(
+        data=[
+            {"id": 7, "org_id": "org-1", "account_login": "acme"},
+            {"id": 8, "org_id": "org-2", "account_login": "other"},
+        ]
+    )
+
+    with patch.object(tasks, "get_supabase", return_value=supabase), patch.object(
+        tasks, "sync_installation_repositories", side_effect=[2, 3]
+    ) as sync:
+        task = tasks.sync_repositories
+        result = task.run() if hasattr(task, "run") else task(None)
+
+    assert result == {
+        "installations_processed": 2,
+        "repositories_synced": 5,
+        "errors": [],
+    }
+    assert sync.call_args_list[0].args == (supabase, 7, "org-1")
+    assert sync.call_args_list[1].args == (supabase, 8, "org-2")


### PR DESCRIPTION
Fixes #212

## Summary

Wire the scheduled repository synchronization task to active GitHub App installations so repository records are actually fetched and upserted. Use the synchronous Supabase client without awaiting it, remove the nonexistent access-token column from worker reads, and return per-installation sync counts and errors.

## Validation

- Full backend pytest suite passes.
- Black and selected Flake8 checks pass.
- Focused GitHub App synchronization regression tests pass.