### PR TITLE
fix(dashboard): sanitize supabase URL and keys against malformed formatting

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -8,12 +8,10 @@ import { BrainCircuit, GitPullRequest, Search, FileCode, CheckCircle, Activity, 
 import { motion } from "framer-motion";
 import WebIDE from "../components/WebIDE";
 import dynamic from 'next/dynamic';
-import { createClient } from '@supabase/supabase-js';
 import { AuthProvider, useAuth } from '@/lib/auth';
+import { getBrowserClient } from '@/lib/supabase';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-key';
-const supabase = createClient(supabaseUrl, supabaseKey);
+const supabase = getBrowserClient();
 
 const InteractiveTerminal = dynamic(() => import('../components/InteractiveTerminal'), { ssr: false });
 

--- a/dashboard/src/lib/supabase-server.ts
+++ b/dashboard/src/lib/supabase-server.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { createClient } from '@supabase/supabase-js';
+import { sanitizeSupabaseUrl } from './supabase';
 
 /**
  * Service role client for admin/server operations.
@@ -19,7 +20,9 @@ export const createServiceClient = () => {
     );
   }
 
-  return createClient(supabaseUrl, serviceKey, {
+  const cleanUrl = sanitizeSupabaseUrl(supabaseUrl);
+
+  return createClient(cleanUrl, serviceKey.trim().replace(/^['"]+|['"]+$/g, ''), {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/dashboard/src/lib/supabase.ts
+++ b/dashboard/src/lib/supabase.ts
@@ -1,7 +1,30 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-key';
+export function sanitizeSupabaseUrl(rawUrl?: string): string {
+  if (!rawUrl) return 'https://placeholder.supabase.co';
+  let cleaned = rawUrl.trim().replace(/^['"]+|['"]+$/g, '');
+  if (!cleaned) return 'https://placeholder.supabase.co';
+
+  // If user pasted just the reference id like "wcskhdvvlnplgynhwfqq"
+  if (/^[a-z0-9-]+$/i.test(cleaned) && !cleaned.includes('.')) {
+    return `https://${cleaned}.supabase.co`;
+  }
+
+  // Ensure protocol
+  if (!cleaned.startsWith('http://') && !cleaned.startsWith('https://')) {
+    cleaned = `https://${cleaned}`;
+  }
+
+  try {
+    const parsed = new URL(cleaned);
+    return parsed.origin;
+  } catch {
+    return 'https://placeholder.supabase.co';
+  }
+}
+
+const supabaseUrl = sanitizeSupabaseUrl(process.env.NEXT_PUBLIC_SUPABASE_URL);
+const supabaseAnonKey = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-key').trim().replace(/^['"]+|['"]+$/g, '');
 
 // Client for browser (with auth helpers)
 export const createBrowserClient = () => {


### PR DESCRIPTION
## Summary
- Adds \sanitizeSupabaseUrl\ to clean raw Supabase URLs and automatically handle cases where quotes, missing https protocols, or bare project reference IDs were supplied in environment configurations.
- Unifies Supabase client initialization to use \getBrowserClient()\ in \dashboard/src/app/page.tsx\.
- Prevents build-time prerendering crashes on Vercel caused by \Invalid supabaseUrl: Provided URL is malformed\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Supabase connection setup by normalizing URLs and removing surrounding whitespace or quotes from configuration values.
  * Added support for bare Supabase project references and URLs without protocols.
  * Improved handling of server-side service credentials and browser authentication initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->