### PR TITLE
feat(backend): support dynamic CORS origins and Vercel preview domains

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -259,9 +259,20 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="AutoMaintainer Backend", lifespan=lifespan)
 
 # Allow the Next.js frontend to connect to this API
+cors_origins_env = os.getenv(
+    "CORS_ORIGINS",
+    "http://localhost:3000,http://127.0.0.1:3000",
+)
+allowed_origins = [
+    origin.strip() for origin in cors_origins_env.split(",") if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_origins=allowed_origins if allowed_origins else ["*"],
+    allow_origin_regex=os.getenv(
+        "CORS_ORIGIN_REGEX", r"^https:\/\/.*\.vercel\.app$"
+    ),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -270,9 +270,7 @@ allowed_origins = [
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins if allowed_origins else ["*"],
-    allow_origin_regex=os.getenv(
-        "CORS_ORIGIN_REGEX", r"^https:\/\/.*\.vercel\.app$"
-    ),
+    allow_origin_regex=os.getenv("CORS_ORIGIN_REGEX", r"^https:\/\/.*\.vercel\.app$"),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Reads \CORS_ORIGINS\ from environment variables (comma-separated list) to allow custom production and staging frontend domains.
- Adds \llow_origin_regex\ defaulting to \^https:\/\/.*\.vercel\.app$\ (customizable via \CORS_ORIGIN_REGEX\), allowing Vercel preview and production deployments to communicate with the FastAPI backend without CORS blockages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin request handling by supporting configurable allowed origins and origin patterns.
  * Added safer handling for empty or whitespace-only origin configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->