### PR TITLE
fix(backend): sanitize Supabase env variables and improve healthz reporting

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -30,8 +30,16 @@ GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 gh = Github(GITHUB_TOKEN) if GITHUB_TOKEN else None
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
+
+def _clean_env(val: str | None) -> str | None:
+    if not val:
+        return None
+    cleaned = val.strip().strip("'\"").strip()
+    return cleaned if cleaned else None
+
+
+SUPABASE_URL = _clean_env(os.getenv("SUPABASE_URL"))
+SUPABASE_SERVICE_KEY = _clean_env(os.getenv("SUPABASE_SERVICE_KEY"))
 supabase: Client | None = None
 if SUPABASE_URL and SUPABASE_SERVICE_KEY:
     supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_KEY)

--- a/backend/main.py
+++ b/backend/main.py
@@ -290,7 +290,7 @@ async def healthz_supabase():
     if not supabase:
         raise HTTPException(
             status_code=503,
-            detail="Supabase is not configured. Please check environment variables.",
+            detail="Supabase is not configured. Please check SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables.",
         )
     try:
         await asyncio.to_thread(
@@ -301,7 +301,7 @@ async def healthz_supabase():
         logger.error(f"Supabase connection check failed: {e}", exc_info=True)
         raise HTTPException(
             status_code=503,
-            detail="Supabase connection failed (database may be paused or unreachable)",
+            detail=f"Supabase connection failed: {e}",
         )
 
 


### PR DESCRIPTION
## Summary
- Automatically strips leading/trailing whitespace and quotes from \SUPABASE_URL\ and \SUPABASE_SERVICE_KEY\ in \ackend/agents.py\ to prevent DNS resolution errors (such as \[Errno -2] Name or service not known\).
- Updates \/healthz/supabase\ to return the exact exception details when connection checks fail, allowing immediate diagnosis.