### PR TITLE
fix(backend): include target host diagnostic in healthz_supabase error response

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -285,7 +285,8 @@ async def healthz():
 
 @app.get("/healthz/supabase")
 async def healthz_supabase():
-    from agents import supabase
+    from agents import supabase, SUPABASE_URL
+    from urllib.parse import urlparse
 
     if not supabase:
         raise HTTPException(
@@ -299,9 +300,11 @@ async def healthz_supabase():
         return {"status": "healthy", "database": "connected"}
     except Exception as e:
         logger.error(f"Supabase connection check failed: {e}", exc_info=True)
+        parsed = urlparse(SUPABASE_URL or "")
+        safe_host = parsed.netloc or parsed.path or "unknown"
         raise HTTPException(
             status_code=503,
-            detail=f"Supabase connection failed: {e}",
+            detail=f"Supabase connection failed ({e}) [target_host='{safe_host}']",
         )
 
 


### PR DESCRIPTION
Includes safe target host parsed from SUPABASE_URL in healthz_supabase 503 response to immediately identify DNS / formatting mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Supabase health-check failure messages by including the target host alongside the original connection error.
  - Safely handles the configured Supabase URL when reporting connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->