### PR TITLE
fix(dashboard): handle selectedRunId reset on new run and guest auth prompt on start

### DIFF
--- a/dashboard/src/components/dashboard/DashboardShell.tsx
+++ b/dashboard/src/components/dashboard/DashboardShell.tsx
@@ -32,9 +32,15 @@ export function DashboardShell() {
   const addLogRef = useRef<(entry: LogEntry) => void>(() => {});
 
   // Agent run controller hook
-  const { state: runState, actions: runActions } = useAgentRun((entry) => {
-    addLogRef.current(entry);
-  });
+  const { state: runState, actions: runActions } = useAgentRun(
+    (entry) => {
+      addLogRef.current(entry);
+    },
+    {
+      onRequireAuth: () => setSkipAuth(false),
+      onStart: () => setSelectedRunId(null),
+    }
+  );
 
   const effectiveRunId = selectedRunId || runState.activeRunId;
 

--- a/dashboard/src/lib/hooks/use-agent-run.ts
+++ b/dashboard/src/lib/hooks/use-agent-run.ts
@@ -29,7 +29,15 @@ export interface LogEntry {
   color: string;
 }
 
-export function useAgentRun(onLog: (entry: LogEntry) => void) {
+interface UseAgentRunOptions {
+  onRequireAuth?: () => void;
+  onStart?: () => void;
+}
+
+export function useAgentRun(
+  onLog: (entry: LogEntry) => void,
+  options?: UseAgentRunOptions
+) {
   const { user, session } = useAuth();
   const [isRunning, setIsRunning] = useState(false);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
@@ -55,7 +63,11 @@ export function useAgentRun(onLog: (entry: LogEntry) => void) {
   }, []);
 
   const startStop = useCallback(async () => {
-    if (!user) return;
+    if (!user) {
+      log("Please sign in with GitHub to start an agent run.", "text-amber-400");
+      options?.onRequireAuth?.();
+      return;
+    }
 
     if (!isRunning) {
       if (
@@ -81,6 +93,7 @@ export function useAgentRun(onLog: (entry: LogEntry) => void) {
         return;
       }
 
+      options?.onStart?.();
       setIsRunning(true);
       log(`Triggering AI Agent Loop for ${repoUrl}...`, "text-zinc-500");
 
@@ -152,7 +165,7 @@ export function useAgentRun(onLog: (entry: LogEntry) => void) {
         console.error("Failed to stop agents:", err);
       }
     }
-  }, [isRunning, repoUrl, targetIssue, activeRunId, user, session, log]);
+  }, [isRunning, repoUrl, targetIssue, activeRunId, user, session, log, options]);
 
   const state: AgentRunState = {
     isRunning,


### PR DESCRIPTION
## Summary

This PR addresses two edge-case logic items identified during the frontend audit:

1. **\selectedRunId\ Reset**: When inspecting a historical run from the **Run History** tab and subsequently clicking **Start** to launch a new autonomous loop, \selectedRunId\ is now reset to \
ull\ via the \onStart\ hook callback. This ensures \effectiveRunId\ seamlessly binds to the newly queued run instead of staying locked to the historical run.
2. **Guest Auth Prompt**: When a user is in guest mode (\skipAuth = true\ with \user = null\) and clicks **Start**, the system now logs a clear prompt (\Please sign in with GitHub to start an agent run.\) and triggers \onRequireAuth\ (\setSkipAuth(false)\) to present the GitHub authentication screen.

### 🧪 Verification
- \
pm run lint\ passed (0 errors, 0 warnings).
- \
pm run build\ passed with static export generated in under 2s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling when starting an agent run by prompting sign-in instead of silently stopping.
  * Reset the selected run when a new agent run begins.
  * Restored authentication-required state when sign-in is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->